### PR TITLE
Add flags to check poh on slot range instead of whole car

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/gagliardetto/solana-go"
@@ -115,6 +116,86 @@ type EpochLimits struct {
 
 	NextBlockSlot uint64 // The slot of the first block of the next epoch.
 	NextBlockhash solana.Hash
+
+	StartSlot OptionalUint64 // The slot from which to start poh verification.
+	EndSlot   OptionalUint64 // The slot at which to end poh verification.
+}
+
+// GetActualStartStopSlots() (start, stop uint64)
+func (el *EpochLimits) GetActualStartStopSlots() (start, stop uint64) {
+	if el.StartSlot.IsSet() {
+		start = el.StartSlot.Get()
+	} else {
+		start = el.FirstBlockSlot
+	}
+	if el.EndSlot.IsSet() {
+		stop = el.EndSlot.Get()
+	} else {
+		stop = el.LastBlockSlot
+	}
+	if start > stop {
+		panic(fmt.Sprintf("start slot %d is greater than stop slot %d", start, stop))
+	}
+	return start, stop
+}
+
+type OptionalUint64 struct {
+	Value uint64
+	isSet bool
+}
+
+// implement the flag.Value interface
+func (ou *OptionalUint64) String() string {
+	if ou == nil {
+		return "nil"
+	}
+	if !ou.isSet {
+		return "unset"
+	}
+	return fmt.Sprintf("%d", ou.Value)
+}
+
+func (ou *OptionalUint64) Set(value string) error {
+	if ou == nil {
+		ou = &OptionalUint64{}
+	}
+	v, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse value %s: %s", value, err)
+	}
+	ou.Value = v
+	ou.isSet = true
+	return nil
+}
+
+func (ou *OptionalUint64) SetValue(value uint64) {
+	if ou == nil {
+		ou = &OptionalUint64{}
+	}
+	ou.Value = value
+	ou.isSet = true
+}
+
+func (ou *OptionalUint64) IsSet() bool {
+	if ou == nil {
+		return false
+	}
+	return ou.isSet
+}
+
+func (ou *OptionalUint64) Get() uint64 {
+	if ou == nil {
+		panic("OptionalUint64 is nil")
+	}
+	return ou.Value
+}
+
+func (ou *OptionalUint64) Unset() {
+	if ou == nil {
+		ou = &OptionalUint64{}
+	}
+	ou.Value = 0
+	ou.isSet = false
 }
 
 // AssertPreviousBlockSlot(candidate uint64) error
@@ -241,6 +322,9 @@ type LimitFlags struct {
 
 	NextBlockSlot uint64
 	NextBlockhash string
+
+	StartSlot OptionalUint64
+	EndSlot   OptionalUint64
 }
 
 func (el *LimitFlags) AddToFlagSet(fs *flag.FlagSet) {
@@ -255,6 +339,9 @@ func (el *LimitFlags) AddToFlagSet(fs *flag.FlagSet) {
 
 	fs.Uint64Var(&el.NextBlockSlot, "next-slot", 0, "The slot of the first block of the next epoch.")
 	fs.StringVar(&el.NextBlockhash, "next-hash", "", "The hash of the first block of the next epoch.")
+
+	fs.Var(&el.StartSlot, "start", "The slot from which to start poh verification.")
+	fs.Var(&el.EndSlot, "end", "The slot at which to end poh verification.")
 }
 
 func isFlagPassed(name string, fs *flag.FlagSet) bool {
@@ -315,8 +402,35 @@ func (el *EpochLimits) ApplyOverrides(lfs *LimitFlags, fs *flag.FlagSet) error {
 			el.NextBlockhash = solana.MustHashFromBase58(lfs.NextBlockhash)
 		}
 	}
+	{
+		if isFlagPassed("start", fs) {
+			fmt.Printf("Overriding start slot with %d\n", lfs.StartSlot.Get())
+			el.StartSlot.SetValue(uint64(lfs.StartSlot.Get()))
+			el.FirstBlockSlot = lfs.StartSlot.Get() // We are overriding the first block slot to be the start slot.
+		} else {
+			el.StartSlot.Unset()
+		}
+		if isFlagPassed("end", fs) {
+			fmt.Printf("Overriding end slot with %d\n", lfs.EndSlot.Get())
+			// TODO: check if start is set.
+			if lfs.EndSlot.Get() < (el.StartSlot.Get()) {
+				return fmt.Errorf("end slot must be greater than or equal to start slot")
+			}
+			el.EndSlot = lfs.EndSlot
+			el.LastBlockSlot = (lfs.EndSlot.Get()) // We are overriding the last block slot to be the end slot.
+		} else {
+			el.EndSlot.Unset()
+		}
+	}
 
 	return nil
+}
+
+func (el *EpochLimits) isCustomRange() bool {
+	if el.StartSlot.IsSet() || el.EndSlot.IsSet() {
+		return true
+	}
+	return false
 }
 
 // GetEpochLimits(epoch uint64) (*EpochLimits, error)

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 		if limits.StartSlot.IsSet() {
 			startBlock, err := helper.GetBlock((limits.StartSlot.Get()))
 			if err != nil {
-				klog.Exitf("error: failed to get block for start slot %d (you need to specify a slot that has a produced block): %s", limits.StartSlot, err)
+				klog.Exitf("error: failed to get block for start slot %d (you need to specify a slot that has a produced block): %s", limits.StartSlot.Get(), err)
 			}
 			limits.FirstBlockhash = startBlock.Blockhash // TODO: ????
 			limits.PreviousBlockhash = startBlock.PreviousBlockhash

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 		if limits.EndSlot.IsSet() {
 			endBlock, err := helper.GetBlock((limits.EndSlot.Get()))
 			if err != nil {
-				klog.Exitf("error: failed to get block for end slot %d (you need to specify a slot that has a produced block): %s", limits.EndSlot, err)
+				klog.Exitf("error: failed to get block for end slot %d (you need to specify a slot that has a produced block): %s", limits.EndSlot.Get(), err)
 			}
 			limits.LastBlockhash = endBlock.Blockhash
 			limits.LastBlockSlot = limits.EndSlot.Get()

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	flag.StringVar(&carPath, "car", "", "Path to CAR file")
 	flag.UintVar(&numWorkers, "workers", uint(runtime.NumCPU()), "Number of workers")
 	flag.BoolVar(&noProgress, "no-progress", false, "Disable progress bar")
+	flag.BoolVar(&noProgress, "silent", noProgress, "Disable progress bar")
 	flag.Int64Var(&epochNum, "epoch", -1, "Epoch number")
 	flag.StringVar(&rpcEndpoint, "rpc", rpc.MainNetBeta.RPC, "RPC endpoint")
 	limitFlags.AddToFlagSet(flag.CommandLine)


### PR DESCRIPTION
example: 

`poh-checker --car /media/runner/scratchpad/cars/epoch-50.car --epoch=50 --start=21600100 --end=21600500`

The start and end must be existing blocks (cannot use empty slots).